### PR TITLE
curriculum section fixed

### DIFF
--- a/src/Section/AcaSecTwo.jsx
+++ b/src/Section/AcaSecTwo.jsx
@@ -13,10 +13,6 @@ function AcaSecTwo() {
       }}
     >
       <Container align="center">
-        <Typography variant="subtitle1" my={2} textTransform="uppercase">
-          Online Live Classes
-        </Typography>
-
         <Typography
           variant="h2"
           textTransform="capitalize"

--- a/src/Section/AcadWhyZummit.jsx
+++ b/src/Section/AcadWhyZummit.jsx
@@ -18,10 +18,6 @@ const AcadWhyZummit = () => {
 
   return (
     <Stack className={classes.whyZummit}>
-        <Typography variant='subtitle1' fontSize={16} fontWeight={400} color="text.primary" my={2} textTransform='uppercase'>
-          What makes us unique
-        </Typography>
-
         <Typography variant='h2' color="text.primary" fontSize={64} fontWeight={700} my={2} textTransform='capitalize'>
           Why learn with Zummit Africa?
         </Typography>

--- a/src/Section/Curriculum.jsx
+++ b/src/Section/Curriculum.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Stack, Typography, Box } from '@mui/material';
+import { Grid, Stack, Typography, Container } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 
 import { exampleText3 } from '../pages/example';
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
     backgroundColor: '#081F4A',
     display: 'flex',
     justifyContent: 'center'
-  }
+  },
 });
 
 const Curriculum = () => {
@@ -30,22 +30,10 @@ const Curriculum = () => {
   return (
     <Stack className={classes.curriculum}>
       <Typography
-        variant="subtitle1"
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          color: '#ECF2FD'
-        }}
-        my={2}
-        textTransform="uppercase"
-      >
-        OUR CURRICULUM
-      </Typography>
-
-      <Typography
         variant="h2"
         fontWeight={700}
-        my={2}
+        mt={7}
+        mb={5}
         textTransform="capitalize"
         color="#ECF2FD"
         sx={{
@@ -57,29 +45,26 @@ const Curriculum = () => {
         What you would learn
       </Typography>
 
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center'
-        }}
-      >
+      <Container>
         <Grid
           container
           my={2}
-          mx="auto"
-          spacing={4}
+          spacing={2}
           sx={{
             display: 'flex',
-            justifyContent: 'center'
+            justifyContent: 'center',
           }}
         >
           {exampleText3.map((text) => (
-            <Grid container item key={text.id} xs={12} sm={6} md={4} lg={3}>
+            <Grid container item key={text.id} xs={12} sm={6} md={4} lg={3} sx={{
+              display: 'flex',
+              justifyContent: 'center',
+            }}>
               <CurriculumCard {...text} />
             </Grid>
           ))}
         </Grid>
-      </Box>
+      </Container>
 
       <Typography
         variant="subtitle1"
@@ -113,7 +98,6 @@ const Curriculum = () => {
         >
           <Grid
             sx={{
-              width: '290px',
               alignSelf: 'center'
             }}
             component="img"
@@ -123,7 +107,11 @@ const Curriculum = () => {
             sx={{
               display: 'flex',
               justifyContent: 'space-between',
-              flexWrap: 'wrap'
+              '@media screen and (max-width: 800px)': {
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'column'
+            }
             }}
           >
             <Grid
@@ -140,7 +128,7 @@ const Curriculum = () => {
                 borderRadius: '5px',
                 alignSelf: 'center'
               }}
-              my={2}
+              mb={2}
               component="img"
               src={pandasLogo}
             />
@@ -149,10 +137,7 @@ const Curriculum = () => {
 
         <Grid
           sx={{
-            width: '26rem',
             alignSelf: 'center',
-            margin: '45px',
-            padding: '20px'
           }}
           component="img"
           src={pythonLogo}
@@ -162,25 +147,28 @@ const Curriculum = () => {
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            alignContent: 'center'
+            alignContent: 'center',
           }}
           my={2}
         >
           <Grid
-            // className="break"
             sx={{
               display: 'flex',
               justifyContent: 'space-between',
-              flexWrap: 'wrap'
+              flexWrap: 'wrap',
+              '@media screen and (max-width: 800px)': {
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'column'
+            }
             }}
           >
             <Grid
               sx={{
                 borderRadius: '5px',
                 alignSelf: 'center',
-                width: '20rem'
               }}
-              my={2}
+             
               component="img"
               src={mplibLogo}
             />
@@ -188,7 +176,6 @@ const Curriculum = () => {
               sx={{
                 borderRadius: '5px',
                 alignSelf: 'center',
-                width: '20rem'
               }}
               my={2}
               component="img"
@@ -197,7 +184,6 @@ const Curriculum = () => {
           </Grid>
           <Grid
             sx={{
-              width: '220px',
               alignSelf: 'center',
               borderRadius: '5px'
             }}


### PR DESCRIPTION
made a mistake when checking out to the branch wrote 'P instead of 'p'.
little headings removed,
cards shrinked as much as possible and spacing added around it.
the logos are more responsive and the width has also be shrinked to make it appear more centralized